### PR TITLE
Revert "create utility to choose an example"

### DIFF
--- a/bin/air-examples
+++ b/bin/air-examples
@@ -1,2 +1,0 @@
-use v6.d;
-use Air::Examples;

--- a/lib/Air/Examples.rakumod
+++ b/lib/Air/Examples.rakumod
@@ -1,25 +1,6 @@
 use v6.d;
-use Term::Choose;
 
-unit module Examples;
-=begin rakudoc
-Get the examples from the bin file and allow for a choice
-=end rakudoc 
-multi sub MAIN {
-    my $this = 'Air-examples.raku';
-    my $ex-dir = 'x-bin';
-
-    my @examples = $ex-dir.IO.dir(test=>/'.raku'/)>>.basename.grep({ !m/$this/ }).sort;
-    my $tc = Term::Choose.new(
-        :1mouse,
-        :0order,
-        :2color,
-        :0clear-screen
-    );
-
-    my $chosen;
-    my $proc;
-    $chosen = $tc.choose( @examples, :2layout, :0default );
-    say "Running example: $chosen\nUse Ctr-C to stop server";
-    $proc = run ($*EXECUTABLE, '-I.', "$ex-dir/$chosen");
+module Examples {
+    # deliberately empty
+    # just run a script in /bin
 }


### PR DESCRIPTION
Reverts librasteve/Air-Examples#14

Well I merged right away then cloned, zef installed and tried to get to work.

@finanalyst  - sorry I had to revert this for a couple of reasons:

 - no Term::Choose in META6.json
 - please can you confirm it will work as `air-examples` (I would prefer not to have to type the .raku suffix)
 - it doesn't work (no matter what I tried I could not get the choose dialog to appear)

Please can you check this all works on a clone & install basis and then we can try again?